### PR TITLE
Fix yaml files for the new version of Fabric

### DIFF
--- a/manifests/deploy-schedule.yaml
+++ b/manifests/deploy-schedule.yaml
@@ -17,6 +17,18 @@ spec:
         image: docker.io/ishangulhane/microservice-schedule
         ports:
           - containerPort: 9080
+        imagePullPolicy: Always
+        env:
+          - name: MB_KEYSTORE_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: mb-keystore-password
+                key: password
+          - name: MB_TRUSTSTORE_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: mb-truststore-password
+                key: password
         volumeMounts:
         - name: keystore
           mountPath: /etc/wlp/config/keystore
@@ -27,18 +39,16 @@ spec:
       volumes:
        - name: keystore
          secret:
-           secretName: wlp-keystore
+           secretName: mb-keystore
        - name: truststore
          secret:
-           secretName: wlp-truststore
+           secretName: mb-truststore
        - name: liberty-config
          configMap:
            name: liberty-config
            items:
              - key: keystore.xml
                path: defaults/keystore.xml
-             - key: logging.xml
-               path: defaults/logging.xml
 ---
 apiVersion: v1
 kind: Service

--- a/manifests/deploy-session.yaml
+++ b/manifests/deploy-session.yaml
@@ -17,6 +17,18 @@ spec:
         image: docker.io/ishangulhane/microservice-session
         ports:
           - containerPort: 9080
+        imagePullPolicy: Always
+        env:
+          - name: MB_KEYSTORE_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: mb-keystore-password
+                key: password
+          - name: MB_TRUSTSTORE_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: mb-truststore-password
+                key: password
         volumeMounts:
         - name: keystore
           mountPath: /etc/wlp/config/keystore
@@ -27,18 +39,16 @@ spec:
       volumes:
       - name: keystore
         secret:
-          secretName: wlp-keystore
+          secretName: mb-keystore
       - name: truststore
         secret:
-          secretName: wlp-truststore
+          secretName: mb-truststore
       - name: liberty-config
         configMap:
           name: liberty-config
           items:
             - key: keystore.xml
               path: defaults/keystore.xml
-            - key: logging.xml
-              path: defaults/logging.xml
 ---
 apiVersion: v1
 kind: Service

--- a/manifests/deploy-speaker.yaml
+++ b/manifests/deploy-speaker.yaml
@@ -17,6 +17,18 @@ spec:
         image: docker.io/ishangulhane/microservice-speaker
         ports:
           - containerPort: 9080
+        imagePullPolicy: Always
+        env:
+          - name: MB_KEYSTORE_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: mb-keystore-password
+                key: password
+          - name: MB_TRUSTSTORE_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: mb-truststore-password
+                key: password
         volumeMounts:
         - name: keystore
           mountPath: /etc/wlp/config/keystore
@@ -27,18 +39,16 @@ spec:
       volumes:
       - name: keystore
         secret:
-          secretName: wlp-keystore
+          secretName: mb-keystore
       - name: truststore
         secret:
-          secretName: wlp-truststore
+          secretName: mb-truststore
       - name: liberty-config
         configMap:
           name: liberty-config
           items:
             - key: keystore.xml
               path: defaults/keystore.xml
-            - key: logging.xml
-              path: defaults/logging.xml
 ---
 apiVersion: v1
 kind: Service

--- a/manifests/deploy-vote.yaml
+++ b/manifests/deploy-vote.yaml
@@ -17,6 +17,18 @@ spec:
         image: docker.io/ishangulhane/microservice-vote
         ports:
           - containerPort: 9080
+        imagePullPolicy: Always
+        env:
+          - name: MB_KEYSTORE_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: mb-keystore-password
+                key: password
+          - name: MB_TRUSTSTORE_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: mb-truststore-password
+                key: password
         volumeMounts:
         - name: keystore
           mountPath: /etc/wlp/config/keystore
@@ -27,18 +39,16 @@ spec:
       volumes:
       - name: keystore
         secret:
-          secretName: wlp-keystore
+          secretName: mb-keystore
       - name: truststore
         secret:
-          secretName: wlp-truststore
+          secretName: mb-truststore
       - name: liberty-config
         configMap:
           name: liberty-config
           items:
             - key: keystore.xml
               path: defaults/keystore.xml
-            - key: logging.xml
-              path: defaults/logging.xml
 ---
 apiVersion: v1
 kind: Service

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -7,7 +7,7 @@ curl -L "https://cli.run.pivotal.io/stable?release=linux64-binary&source=github"
 sudo mv cf /usr/local/bin
 sudo curl -o /usr/share/bash-completion/completions/cf https://raw.githubusercontent.com/cloudfoundry/cli/master/ci/installers/completion/cf
 cf --version
-curl -L public.dhe.ibm.com/cloud/bluemix/cli/bluemix-cli/Bluemix_CLI_0.5.1_amd64.tar.gz > Bluemix_CLI.tar.gz
+curl -L public.dhe.ibm.com/cloud/bluemix/cli/bluemix-cli/Bluemix_CLI_0.5.5_amd64.tar.gz > Bluemix_CLI.tar.gz
 tar -xvf Bluemix_CLI.tar.gz
 cd Bluemix_CLI
 sudo ./install_bluemix_cli
@@ -30,8 +30,8 @@ sleep 3m
 }
 
 function run_tests() {
-bx cs workers anthony-cluster
-$(bx cs cluster-config anthony-cluster | grep -v "Downloading" | grep -v "OK" | grep -v "The")
+bx cs workers $cluster
+$(bx cs cluster-config $cluster | grep -v "Downloading" | grep -v "OK" | grep -v "The")
 
 echo "Creating Deployments"
 git clone https://github.com/IBM/java-microprofile-on-kubernetes.git


### PR DESCRIPTION
- Rename and add environment variables for the keystore and truststore because the new Fabric renamed the secrets.
- Remove Logging.xml for liberty-config because it no longer exists in the new Fabric (For collecting logs, we need to add a new add-on from https://github.com/WASdev/sample.microservicebuilder.helm.elk/blob/master/installing_sample_elk_task.md)
- update Travis so it can use different cluster name