### PR TITLE
add ICP instructions

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright {yyyy} {name of copyright owner}
+   Copyright 2017, International Business Machines Corporation
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/README.md
+++ b/README.md
@@ -19,9 +19,13 @@ The Microservice Builder [sample application](https://github.com/WASdev/sample.m
 - [Bluemix DevOps Toolchain Service](https://console.ng.bluemix.net/catalog/services/continuous-delivery)
 - [Bluemix Container Service](https://console.ng.bluemix.net/catalog/?taxonomyNavigation=apps&category=containers)
 
-## Prerequisite
+## Prerequisites
 
-* Create a Kubernetes cluster with either [Minikube](https://kubernetes.io/docs/getting-started-guides/minikube) for local testing, or with [IBM Bluemix Container Service](https://github.com/IBM/container-journey-template) to deploy in cloud. For deploying on Minikube follow the instructions [here](https://github.com/WASdev/sample.microservicebuilder.docs/blob/master/dev_test_local_minikube.md)
+* Create a Kubernetes cluster.  Options include:
+ * [Minikube](https://kubernetes.io/docs/getting-started-guides/minikube) for local testing
+ * [IBM Bluemix Container Service](https://github.com/IBM/container-journey-template) to deploy in cloud, or
+ * [IBM Cloud Private](https://www.ibm.com/cloud-computing/products/ibm-cloud-private/) for either senario.
+For deploying on Minikube follow the instructions [here](https://github.com/WASdev/sample.microservicebuilder.docs/blob/master/dev_test_local_minikube.md).  For deploying on IBM Cloud Private follow the instructions [here](docs/deploy-with-ICP.md)
 * The code in this particular repository is regularly tested against [Kubernetes Cluster from Bluemix Container Service](https://console.ng.bluemix.net/docs/containers/cs_ov.html#cs_ov) using Travis.
 * Install a Git client to obtain the sample code.
 

--- a/docs/deploy-with-ICP.md
+++ b/docs/deploy-with-ICP.md
@@ -1,0 +1,47 @@
+# Deploy with IBM Cloud Private
+
+Deploying MicroProfile with IBM Cloud Private essentially follows the same
+pattern as the other platform options.
+
+## Prerequisite
+
+Follow the [instructions](https://github.com/IBM/deploy-ibm-cloud-private)
+to either install a local instance of IBM Cloud private via Vagrant or a remote
+instance at Softlayer. These instructions assume the former.
+
+## Steps
+
+Log into the ICP web UI. 
+
+### 1. Install Microservices Builder fabric
+
+From the navigation menu on the upper left, select App Center.  Scroll down
+until you see 'microservicesbuilder/fabric', and click the Install Package
+button below it.  Accept the license and Review and Install.
+
+### 2. Install Microservice Builder ELK sample
+
+From the navigation menu, select System and then the Repositories tab.
+Click the Add Repository button all the way to the right then add:
+
+     Repositry Name
+     mb-sample
+
+     URL
+     https://wasdev.github.io/sample.microservicebuilder.helm.elk/charts
+
+Click Add.
+Back in the App Center, find mb-sample/sample-elk, click Install Package and
+finally, click Install Package.
+
+### 3. Deploy the sample application
+
+Now you will need to access your Vagrant VM
+
+```bash
+$ vagrant ssh
+```
+
+From here, you can follow along with the instructions in the
+[root](../README.md#2-get-and-build-the-application-code) of this repo to
+deploy the sample application.


### PR DESCRIPTION
This commit adds a doc to detail how one would use the web UI in ICP to setup an instance of MicroProfile.  It adds a reference to this doc on the main README.

also: fills out the company info in the LICENSE file